### PR TITLE
Maintain UUID for backend ID after restarts

### DIFF
--- a/src/dataclay/backend/api.py
+++ b/src/dataclay/backend/api.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import os.path
 import pickle
 import time
 import traceback
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional
+from uuid import UUID, uuid4
 
 from dataclay import utils
 from dataclay.config import settings
@@ -19,8 +21,6 @@ from dataclay.utils.serialization import dcdumps, recursive_dcloads
 from dataclay.utils.telemetry import trace
 
 if TYPE_CHECKING:
-    from uuid import UUID
-
     from dataclay.dataclay_object import DataClayObject
 
 tracer = trace.get_tracer(__name__)
@@ -35,9 +35,49 @@ class BackendAPI:
         self.port = port
 
         # Initialize runtime
-        self.backend_id = settings.backend.id
+        self.backend_id = self._get_or_generate_backend_id()
         self.runtime = BackendRuntime(kv_host, kv_port, self.backend_id)
         set_runtime(self.runtime)
+
+    @staticmethod
+    def _get_or_generate_backend_id() -> UUID:
+        """Try to retrieve this backend UUID, or generate a new one.
+        
+        If there is no backend_id defined in the settings, try to get the
+        backend UUID. A file may exist in the storage folder (which means that
+        this backend already has a identifer, so we should reuse it).
+
+        If there is no UUID in persistent storage, then this means that this is
+        the first time this backend has started, so we generate a new one and
+        store it.
+        """
+        backend_id_file = os.path.join(settings.storage_path, "BACKEND_ID")
+
+        if settings.backend.id is None and os.path.exists(backend_id_file):
+            # Seems like we will be using a preexisting UUID
+            with open(backend_id_file, "rt") as f:
+                ret = UUID(f.read())
+                logger.info("Starting backend with recovered UUID: %s", ret)
+                return ret
+
+        if settings.backend.id is None:
+            backend_id = uuid4()
+            logger.info("BackendID randomly generated: %s", backend_id)
+        else:
+            backend_id = settings.backend_id
+            logger.info("BackendID defined in settings: %s", backend_id)
+        
+        # Store the backend_id and return it
+        try:
+            with open(backend_id_file, "wt") as f:
+                f.write(str(backend_id))
+                logger.debug("BackendID has been stored in the following file: %s", backend_id_file)
+        except OSError:
+            logger.warning("Could not write the BackendID in persistent storage. "
+                           "Restarting this backend may result in unreachable/unrecoverable objects.")
+            logger.debug("Exception when trying to access persistent backend id file:", exc_info=True)
+        return backend_id
+
 
     def is_ready(self, timeout: Optional[float] = None, pause: float = 0.5):
         ref = time.time()

--- a/src/dataclay/backend/servicer.py
+++ b/src/dataclay/backend/servicer.py
@@ -1,7 +1,6 @@
 """ Class description goes here. """
 
 import logging
-import pickle
 import os.path
 import signal
 import threading

--- a/src/dataclay/config.py
+++ b/src/dataclay/config.py
@@ -1,9 +1,9 @@
 import logging
 import socket
 import uuid
-from typing import Literal, Optional
+from typing import Literal, Optional, Annotated
 
-from pydantic import AliasChoices, Field, SecretStr, constr
+from pydantic import AliasChoices, Field, SecretStr, StringConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
     storage_path: str = "/data/storage/"
     check_session: bool = False
     thread_pool_workers: Optional[int] = None
-    loglevel: constr(to_upper=True) = "WARNING"
+    loglevel: Annotated[str, StringConstraints(strip_whitespace=True, to_upper=True)] = "INFO"
 
     # Timeouts
     grpc_check_alive_timeout: int = 60

--- a/src/dataclay/config.py
+++ b/src/dataclay/config.py
@@ -11,7 +11,7 @@ class BackendSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="dataclay_backend_", env_file=".env", secrets_dir="/run/secrets", extra="ignore"
     )
-    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    id: Optional[uuid.UUID] = None
     name: Optional[str] = None
     host: str = socket.gethostbyname(socket.gethostname())
     port: int = 6867

--- a/src/dataclay/runtime/backend.py
+++ b/src/dataclay/runtime/backend.py
@@ -51,6 +51,8 @@ class BackendRuntime(DataClayRuntime):
         # Must be thread-safe.
         self.session_expires_dates = {}
 
+        self.backend_id = backend_id
+
         self.thread_local_data = threading.local()
 
     @property
@@ -69,7 +71,7 @@ class BackendRuntime(DataClayRuntime):
 
     def stop(self):
         # Remove backend entry from metadata
-        self.metadata_service.delete_backend(settings.backend.id)
+        self.metadata_service.delete_backend(self.backend_id)
 
         # Stop DataManager
         logger.debug("Stopping DataManager")


### PR DESCRIPTION
When initializing, backend will try to recover its backend id from the BACKEND_ID file in the persistent storage folder.

If the file exists, it uses that.

If it does not exist, it randomly generates a new one and writes it onto the file.

Setting DATACLAY_BACKEND_ID always has priority (and will potentially overwrite the UUID in the file if it already existed).