### PR TITLE
Add a healthcheck mechanism

### DIFF
--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - DATACLAY_PASSWORD=s3cret
       - DATACLAY_USERNAME=testuser
       - DATACLAY_DATASET=testdata
+      - DATACLAY_METADATA_ENABLE_HEALTHCHECK=True
+      - DATACLAY_LOGLEVEL=info
     command: python -m dataclay.metadata
 
   backend:
@@ -25,6 +27,8 @@ services:
       - redis
     environment:
       - DATACLAY_KV_HOST=redis
+      - DATACLAY_BACKEND_ENABLE_HEALTHCHECK=true
+      - DATACLAY_LOGLEVEL=info
     command: python -m dataclay.backend
     volumes:
       - ./model:/workdir/model:ro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.9"
 dependencies = [
     "bcrypt>=4.0.1",
     "grpcio>=1.59.2",
+    "grpcio-health-checking>=1.59.2",
     "hiredis>=2.2.3",
     "opentelemetry-api>=1.20.0",
     "prometheus-client>=0.18.0",

--- a/src/dataclay/config.py
+++ b/src/dataclay/config.py
@@ -16,6 +16,7 @@ class BackendSettings(BaseSettings):
     host: str = socket.gethostbyname(socket.gethostname())
     port: int = 6867
     listen_address: str = "0.0.0.0"
+    enable_healthcheck: bool = False
 
 
 class MetadataSettings(BaseSettings):
@@ -25,6 +26,7 @@ class MetadataSettings(BaseSettings):
     host: str = socket.gethostbyname(socket.gethostname())
     port: int = 16587
     listen_address: str = "0.0.0.0"
+    enable_healthcheck: bool = False
 
 
 class ClientSettings(BaseSettings):

--- a/src/dataclay/control/ctl.py
+++ b/src/dataclay/control/ctl.py
@@ -5,6 +5,8 @@ import os
 import pprint
 
 import grpc
+from grpc_health.v1 import health_pb2
+from grpc_health.v1 import health_pb2_grpc
 
 from dataclay.backend.client import BackendClient
 from dataclay.metadata.client import MetadataClient
@@ -13,6 +15,16 @@ from dataclay.utils.uuid import UUIDEncoder, uuid_parser
 DATACLAY_LOGLEVEL = os.getenv("DATACLAY_LOGLEVEL", default="INFO").upper()
 logging.basicConfig(level=DATACLAY_LOGLEVEL)
 logger = logging.getLogger(__name__)
+
+
+def healthcheck(host, port, service):
+    with grpc.insecure_channel("%s:%s" % (host, port)) as channel:
+        health_stub = health_pb2_grpc.HealthStub(channel)
+        request = health_pb2.HealthCheckRequest(service=service)
+        resp = health_stub.Check(request)
+
+        if resp.status != health_pb2.HealthCheckResponse.SERVING:
+            exit(1)
 
 
 def new_account(username, password, host, port):
@@ -115,6 +127,18 @@ def main():
     # parser.add_argument("--host", type=str, default="localhost", help="Specify the host (default: localhost)")
     # parser.add_argument("--port", type=int, default=16587, help="Specify the port (default: 16587)")
 
+    # Create the parser for the "healthcheck" command
+    parser_healthcheck = subparsers.add_parser("healthcheck")
+    parser_healthcheck.add_argument(
+        "--host", type=str, default="localhost", help="Specify the host (default: localhost)"
+    )
+    parser_healthcheck.add_argument(
+        "--service", choices=["backend", "metadata"], required=True, help="Specify the kind of service"
+    )
+    parser_healthcheck.add_argument(
+        "--port", type=int, default=0, help="Specify the port (default: inferred from service)"
+    )
+
     # Create the parser for the "new_account" command
     parser_new_account = subparsers.add_parser("new_account")
     parser_new_account.add_argument("username", type=str)
@@ -196,6 +220,13 @@ def main():
     args = parser.parse_args()
 
     match args.function:
+        case "healthcheck":
+            if args.service == "backend":
+                port = args.port or 6867
+                healthcheck(args.host, port, "dataclay.proto.backend.BackendService")
+            elif args.service == "metadata":
+                port = args.port or 16587
+                healthcheck(args.host, port, "dataclay.proto.metadata.MetadataService")
         case "new_account":
             new_account(args.username, args.password, args.host, args.port)
         case "new_session":


### PR DESCRIPTION
grpcio supports a healthcheck. With this, both BackendService and MetadataService support this and can be queried.

`dataclayctl` has a new function that allows to query that healthcheck endpoint.