### PR TITLE
Upgrading gRPC and adding py313 to the actions matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ requires-python = ">=3.9"
 dependencies = [
     "aiorwlock>=1.4.0",
     "bcrypt>=4.0.1",
-    "grpcio>=1.59.2",
-    "grpcio-health-checking>=1.59.2",
+    "grpcio>=1.66.2",
+    "grpcio-health-checking>=1.66.2",
     "hiredis>=2.2.3",
     "opentelemetry-api>=1.20.0",
     "protobuf>=4.25.0",

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py310
     py311
     py312
+    py313
     coverage_report
 
 
@@ -48,3 +49,4 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
Some repository has been updated recently and the GitHub action is able to run green :heavy_check_mark:  

This should be ready to merge.
